### PR TITLE
New and Newf don't contain the stacktrace

### DIFF
--- a/error.go
+++ b/error.go
@@ -57,11 +57,11 @@ func (e *Error) StackTrace() Frames {
 }
 
 func New(msg string) error {
-	return &Error{msg: msg, stackTrace: caller()}
+	return &Error{msg: msg}
 }
 
 func Newf(format string, a ...any) error {
-	return &Error{msg: fmt.Sprintf(format, a...), stackTrace: caller()}
+	return &Error{msg: fmt.Sprintf(format, a...)}
 }
 
 // WithStack annotates err with a stack trace.

--- a/error_test.go
+++ b/error_test.go
@@ -18,6 +18,8 @@ import (
 func TestError(t *testing.T) {
 	e := New("new error")
 	require.NotNil(t, e)
+	assert.Nil(t, StackTrace(e), "The created error should not contain the stacktrace")
+	assert.Nil(t, StackTrace(Newf("new error")), "The created error by Newf should not contain the stacktrace")
 	_, ok := e.(interface {
 		Unwrap() error
 	})


### PR DESCRIPTION
New and Newf don't contain the stacktrace

The stacktrace when create the error is not the valueless stacktrace.
In a lot of case, Errors are created during initialization not execution.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/f110/xerrors/pull/1).
* __->__ #1
