### PR TITLE
StackTrace supports extracting Frames from wrapped error

### DIFF
--- a/error.go
+++ b/error.go
@@ -86,9 +86,11 @@ type Frames []uintptr
 var _ zapcore.ArrayMarshaler = Frames{}
 
 func StackTrace(err error) Frames {
-	if _, ok := err.(*Error); !ok {
+	var sErr *Error
+	if !errors.As(err, &sErr) {
 		return nil
 	}
+	err = sErr
 
 	var frames Frames
 	for {

--- a/error_test.go
+++ b/error_test.go
@@ -44,6 +44,9 @@ func TestStackTrace(t *testing.T) {
 	frames := StackTrace(e)
 	_, filename, _, _ := runtime.Caller(1)
 	assert.Contains(t, frames.String(), filename)
+
+	wrapped := fmt.Errorf(": %w", e)
+	assert.NotNil(t, StackTrace(wrapped))
 }
 
 func TestWithMessage(t *testing.T) {


### PR DESCRIPTION
StackTrace supports extracting Frames from wrapped error
